### PR TITLE
Bugfix/Wrong number of features

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -42,6 +42,7 @@ def build_configuration() -> tuple[Namespace, Namespace, Namespace, str]:
         dependent_variable=st.session_state[ConfigStateKeys.DependentVariableName],
         experiment_name=st.session_state[ConfigStateKeys.ExperimentName],
         problem_type=st.session_state[ConfigStateKeys.ProblemType].lower(),
+        is_granularity=st.session_state[ConfigStateKeys.GranularFeatures],
     )
     fuzzy_opt = fuzzy_opt.parse()
 


### PR DESCRIPTION
## Description
- A missing configuration for the granular features in the fuzzy portion of the pipeline was causing the granularity to always run. This led to the wrong number of features being passed to models and breaking the pipeline.
- The missing config has been added to the UI.

## Linked issues
- Closes #40 