### PR TITLE
Bugfix/save preproc to new file

### DIFF
--- a/biofefi/components/forms.py
+++ b/biofefi/components/forms.py
@@ -6,9 +6,10 @@ import streamlit as st
 from sklearn.manifold import TSNE
 from sklearn.preprocessing import MinMaxScaler, StandardScaler
 
-from biofefi.options.choices.ui import SVM_KERNELS
+from biofefi.options.choices.ui import NORMALISATIONS, SVM_KERNELS, TRANSFORMATIONS_Y
 from biofefi.options.enums import (
     DataAnalysisStateKeys,
+    DataPreprocessingStateKeys,
     ExecutionStateKeys,
     FeatureImportanceStateKeys,
     FuzzyStateKeys,
@@ -16,6 +17,7 @@ from biofefi.options.enums import (
     Normalisations,
     PlotOptionKeys,
     ProblemTypes,
+    TransformationsY,
 )
 from biofefi.options.file_paths import biofefi_experiments_base_dir, ml_model_dir
 from biofefi.options.search_grids import (
@@ -741,3 +743,110 @@ def _svm_opts(use_hyperparam_search: bool) -> dict:
         "params": params,
     }
     return model_types
+
+
+@st.experimental_fragment
+def preprocessing_opts_form(data: pd.DataFrame):
+    st.write("## Data Preprocessing Options")
+
+    st.write("### Data Normalisation")
+
+    st.write(
+        """
+        If you select **"Standardization"**, your data will be normalised by subtracting the
+        mean and dividing by the standard deviation for each feature. The resulting transformation has a
+        mean of 0 and values are between -1 and 1.
+
+        If you select **"Minmax"**, your data will be scaled based on the minimum and maximum
+        value of each feature. The resulting transformation will have values between 0 and 1.
+
+        If you select **"None"**, the data will not be normalised.
+        """
+    )
+
+    st.write("#### Normalisation Method for Independent Variables")
+
+    st.selectbox(
+        "Normalisation",
+        NORMALISATIONS,
+        key=DataPreprocessingStateKeys.IndependentNormalisation,
+        index=len(NORMALISATIONS) - 1,  # default to no normalisation
+    )
+
+    st.write("#### Transformation Method for Dependent Variable")
+
+    transformationy = st.selectbox(
+        "Transformations",
+        TRANSFORMATIONS_Y,
+        key=DataPreprocessingStateKeys.DependentNormalisation,
+        index=len(TRANSFORMATIONS_Y) - 1,  # default to no transformation
+    )
+
+    if (
+        transformationy.lower() == TransformationsY.Log
+        or transformationy.lower() == TransformationsY.Sqrt
+    ):
+        if (
+            data.iloc[:, -1].min() <= 0
+        ):  # deal with user attempting this transformations on negative values
+            st.warning(
+                "The dependent variable contains negative values. Log and square root transformations require positive values."
+            )
+            if st.checkbox(
+                "Proceed with transformation. This option will add a constant to the dependent variable to make it positive.",
+                key=DataPreprocessingStateKeys.ProceedTransformation,
+            ):
+                pass
+            else:
+                st.stop()
+
+    st.write("### Feature Selection")
+
+    st.write("#### Check the Feature Selection Algorithms to Use")
+
+    variance_disabled = True
+    if st.checkbox(
+        "Variance threshold",
+        key=DataPreprocessingStateKeys.VarianceThreshold,
+        help="Delete features with variance below a certain threshold",
+    ):
+        variance_disabled = False
+    st.number_input(
+        "Set threshold",
+        min_value=0.0,
+        max_value=1.0,
+        value=0.1,
+        key=DataPreprocessingStateKeys.ThresholdVariance,
+        disabled=variance_disabled,
+    )
+
+    correlation_disabled = True
+    if st.checkbox(
+        "Correlation threshold",
+        key=DataPreprocessingStateKeys.CorrelationThreshold,
+        help="Delete features with correlation above a certain threshold",
+    ):
+        correlation_disabled = False
+    st.number_input(
+        "Set threshold",
+        min_value=0.0,
+        max_value=1.0,
+        value=0.8,
+        key=DataPreprocessingStateKeys.ThresholdCorrelation,
+        disabled=correlation_disabled,
+    )
+
+    lasso_disabled = True
+    if st.checkbox(
+        "Lasso Feature Selection",
+        key=DataPreprocessingStateKeys.LassoFeatureSelection,
+        help="Select features using Lasso regression",
+    ):
+        lasso_disabled = False
+    st.number_input(
+        "Set regularisation term",
+        min_value=0.0,
+        value=0.05,
+        key=DataPreprocessingStateKeys.RegularisationTerm,
+        disabled=lasso_disabled,
+    )

--- a/biofefi/components/preprocessing.py
+++ b/biofefi/components/preprocessing.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.experimental_fragment
+def preprocessed_view(data: pd.DataFrame):
+    """Display the preprocessed data to the user.
+
+    Args:
+        data (pd.DataFrame): The preprocessed data to show.
+    """
+    st.write("### Processed Data")
+    st.write(data)
+    st.write("### Processed Data Description")
+    st.write(data.describe())

--- a/biofefi/components/preprocessing.py
+++ b/biofefi/components/preprocessing.py
@@ -13,3 +13,16 @@ def preprocessed_view(data: pd.DataFrame):
     st.write(data)
     st.write("### Processed Data Description")
     st.write(data.describe())
+
+
+@st.experimental_fragment
+def original_view(data: pd.DataFrame):
+    """Display the original data to the user.
+
+    Args:
+        data (pd.DataFrame): The original data to show.
+    """
+    st.write("### Original Data")
+    st.write(data)
+    st.write("### Original Data Description")
+    st.write(data.describe())

--- a/biofefi/options/execution.py
+++ b/biofefi/options/execution.py
@@ -14,4 +14,3 @@ class ExecutionOptions:
     normalization: Normalisations = Normalisations.NoNormalisation
     n_bootstraps: int = 3
     use_hyperparam_search: bool = True
-    data_is_preprocessed: bool = False

--- a/biofefi/options/execution.py
+++ b/biofefi/options/execution.py
@@ -14,3 +14,4 @@ class ExecutionOptions:
     normalization: Normalisations = Normalisations.NoNormalisation
     n_bootstraps: int = 3
     use_hyperparam_search: bool = True
+    data_is_preprocessed: bool = False

--- a/biofefi/options/file_paths.py
+++ b/biofefi/options/file_paths.py
@@ -24,7 +24,7 @@ def preprocessed_data_path(file_name: str, experiment_path: Path) -> Path:
     Returns:
         Path: The full path for the raw data directory.
     """
-    file_name = file_name.split(".")[0] + "_raw.csv"
+    file_name = file_name.split(".")[0] + "_preprocessed.csv"
 
     return experiment_path / file_name
 

--- a/biofefi/options/file_paths.py
+++ b/biofefi/options/file_paths.py
@@ -14,7 +14,7 @@ def uploaded_file_path(file_name: str, experiment_path: Path) -> Path:
     return experiment_path / file_name
 
 
-def raw_data_path(file_name: str, experiment_path: Path) -> Path:
+def preprocessed_data_path(file_name: str, experiment_path: Path) -> Path:
     """Create the full path to the directory to save raw data.
 
     Args:

--- a/biofefi/options/preprocessing.py
+++ b/biofefi/options/preprocessing.py
@@ -9,3 +9,4 @@ class PreprocessingOptions:
     lasso_regularisation_term: float
     independent_variable_normalisation: str = "none"
     dependent_variable_transformation: str = "none"
+    data_is_preprocessed: bool = False

--- a/biofefi/pages/2_Data_Preprocessing.py
+++ b/biofefi/pages/2_Data_Preprocessing.py
@@ -3,12 +3,12 @@ import pandas as pd
 import streamlit as st
 
 from biofefi.components.experiments import experiment_selector
+from biofefi.components.forms import preprocessing_opts_form
 from biofefi.components.images.logos import sidebar_logo
-from biofefi.options.choices.ui import NORMALISATIONS, TRANSFORMATIONS_Y
+from biofefi.components.preprocessing import original_view, preprocessed_view
 from biofefi.options.enums import (
     DataPreprocessingStateKeys,
     ExecutionStateKeys,
-    TransformationsY,
 )
 from biofefi.options.file_paths import (
     biofefi_experiments_base_dir,
@@ -109,124 +109,11 @@ if experiment_name:
         biofefi_base_dir / experiment_name,
     )
 
-    # if path_to_preprocessed_data.exists():
-    #     data = pd.read_csv(path_to_preprocessed_data)
-    # else:
-    #     data = pd.read_csv(exec_opt.data_path)
-
     plot_opt = load_plot_options(path_to_plot_opts)
 
-    st.write("### Original Data")
+    original_view(data)
 
-    st.write(data)
-
-    st.write("### Data Description")
-
-    st.write(data.describe())
-
-    st.write("## Data Preprocessing Options")
-
-    st.write("#### Data Normalisation")
-
-    st.write(
-        """
-        If you select **"Standardization"**, your data will be normalised by subtracting the
-        mean and dividing by the standard deviation for each feature. The resulting transformation has a
-        mean of 0 and values are between -1 and 1.
-
-        If you select **"Minmax"**, your data will be scaled based on the minimum and maximum
-        value of each feature. The resulting transformation will have values between 0 and 1.
-
-        If you select **"None"**, the data will not be normalised.
-        """
-    )
-
-    st.write("#### Normalisation Method for Independent Variables")
-
-    st.selectbox(
-        "Normalisation",
-        NORMALISATIONS,
-        key=DataPreprocessingStateKeys.IndependentNormalisation,
-        index=len(NORMALISATIONS) - 1,  # default to no normalisation
-    )
-
-    st.write("#### Transformation Method for Dependent Variable")
-
-    transformationy = st.selectbox(
-        "Transformations",
-        TRANSFORMATIONS_Y,
-        key=DataPreprocessingStateKeys.DependentNormalisation,
-        index=len(TRANSFORMATIONS_Y) - 1,  # default to no transformation
-    )
-
-    if (
-        transformationy.lower() == TransformationsY.Log
-        or transformationy.lower() == TransformationsY.Sqrt
-    ):
-        if (
-            data.iloc[:, -1].min() <= 0
-        ):  # deal with user attempting this transformations on negative values
-            st.warning(
-                "The dependent variable contains negative values. Log and square root transformations require positive values."
-            )
-            if st.checkbox(
-                "Proceed with transformation. This option will add a constant to the dependent variable to make it positive.",
-                key=DataPreprocessingStateKeys.ProceedTransformation,
-            ):
-                pass
-            else:
-                st.stop()
-
-    st.write("#### Feature Selection")
-
-    st.write("#### Check the Feature Selection Algorithms to Use")
-
-    variance_disabled = True
-    if st.checkbox(
-        "Variance threshold",
-        key=DataPreprocessingStateKeys.VarianceThreshold,
-        help="Delete features with variance below a certain threshold",
-    ):
-        variance_disabled = False
-    threshold = st.number_input(
-        "Set threshold",
-        min_value=0.0,
-        max_value=1.0,
-        value=0.1,
-        key=DataPreprocessingStateKeys.ThresholdVariance,
-        disabled=variance_disabled,
-    )
-
-    correlation_disabled = True
-    if st.checkbox(
-        "Correlation threshold",
-        key=DataPreprocessingStateKeys.CorrelationThreshold,
-        help="Delete features with correlation above a certain threshold",
-    ):
-        correlation_disabled = False
-    threshold = st.number_input(
-        "Set threshold",
-        min_value=0.0,
-        max_value=1.0,
-        value=0.8,
-        key=DataPreprocessingStateKeys.ThresholdCorrelation,
-        disabled=correlation_disabled,
-    )
-
-    lasso_disabled = True
-    if st.checkbox(
-        "Lasso Feature Selection",
-        key=DataPreprocessingStateKeys.LassoFeatureSelection,
-        help="Select features using Lasso regression",
-    ):
-        lasso_disabled = False
-    regularisation_term = st.number_input(
-        "Set regularisation term",
-        min_value=0.0,
-        value=0.05,
-        key=DataPreprocessingStateKeys.RegularisationTerm,
-        disabled=lasso_disabled,
-    )
+    preprocessing_opts_form(data)
 
     if st.button("Run Data Preprocessing", type="primary"):
 
@@ -247,11 +134,4 @@ if experiment_name:
         save_options(path_to_exec_opts, exec_opt)
 
         st.success("Data Preprocessing Complete")
-
-        st.write("### Processed Data")
-
-        st.write(processed_data)
-
-        st.write("### Processed Data Description")
-
-        st.write(processed_data.describe())
+        preprocessed_view(processed_data)

--- a/biofefi/pages/2_Data_Preprocessing.py
+++ b/biofefi/pages/2_Data_Preprocessing.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import pandas as pd
 import streamlit as st
 
@@ -6,10 +7,7 @@ from biofefi.components.experiments import experiment_selector
 from biofefi.components.forms import preprocessing_opts_form
 from biofefi.components.images.logos import sidebar_logo
 from biofefi.components.preprocessing import original_view, preprocessed_view
-from biofefi.options.enums import (
-    DataPreprocessingStateKeys,
-    ExecutionStateKeys,
-)
+from biofefi.options.enums import DataPreprocessingStateKeys, ExecutionStateKeys
 from biofefi.options.file_paths import (
     biofefi_experiments_base_dir,
     data_preprocessing_options_path,

--- a/biofefi/pages/2_Data_Preprocessing.py
+++ b/biofefi/pages/2_Data_Preprocessing.py
@@ -13,7 +13,7 @@ from biofefi.options.file_paths import (
     biofefi_experiments_base_dir,
     execution_options_path,
     plot_options_path,
-    raw_data_path,
+    preprocessed_data_path,
 )
 from biofefi.options.preprocessing import PreprocessingOptions
 from biofefi.services.configuration import load_execution_options, load_plot_options
@@ -84,7 +84,7 @@ if experiment_name:
 
     path_to_plot_opts = plot_options_path(biofefi_base_dir / experiment_name)
 
-    path_to_raw_data = raw_data_path(
+    path_to_raw_data = preprocessed_data_path(
         exec_opt.data_path.split("/")[-1],
         biofefi_base_dir / experiment_name,
     )

--- a/biofefi/pages/2_Data_Preprocessing.py
+++ b/biofefi/pages/2_Data_Preprocessing.py
@@ -12,12 +12,14 @@ from biofefi.options.enums import (
 )
 from biofefi.options.file_paths import (
     biofefi_experiments_base_dir,
+    data_preprocessing_options_path,
     execution_options_path,
     plot_options_path,
     preprocessed_data_path,
 )
 from biofefi.options.preprocessing import PreprocessingOptions
 from biofefi.services.configuration import (
+    load_data_preprocessing_options,
     load_execution_options,
     load_plot_options,
     save_options,
@@ -89,8 +91,17 @@ if experiment_name:
 
     path_to_plot_opts = plot_options_path(biofefi_base_dir / experiment_name)
 
+    path_to_preproc_opts = data_preprocessing_options_path(
+        biofefi_base_dir / experiment_name
+    )
+
+    data_is_preprocessed = False
+    if path_to_preproc_opts.exists():
+        preproc_opts = load_data_preprocessing_options(path_to_preproc_opts)
+        data_is_preprocessed = preproc_opts.data_is_preprocessed
+
     # Check if the user has already preprocessed their data
-    if exec_opt.data_is_preprocessed:
+    if data_is_preprocessed:
         st.warning("Your data are already preprocessed. Would you like to start again?")
         preproc_again = st.checkbox("Redo preprocessing", value=False)
     else:
@@ -104,8 +115,6 @@ if experiment_name:
     else:
         # remove preprocessed suffix to point to original data file
         exec_opt.data_path = exec_opt.data_path.replace("_preprocessed", "")
-        # set data_is_preprocessed to False
-        exec_opt.data_is_preprocessed = False
 
         data = pd.read_csv(exec_opt.data_path)
 
@@ -133,8 +142,6 @@ if experiment_name:
 
             # Update exec opts to point to the pre-processed data
             exec_opt.data_path = str(path_to_preprocessed_data)
-            # Set data_is_preprocessed to True
-            exec_opt.data_is_preprocessed = True
             save_options(path_to_exec_opts, exec_opt)
 
             st.success("Data Preprocessing Complete")

--- a/biofefi/pages/3_Data_Visualisation.py
+++ b/biofefi/pages/3_Data_Visualisation.py
@@ -16,7 +16,7 @@ from biofefi.options.file_paths import (
     data_analysis_plots_dir,
     execution_options_path,
     plot_options_path,
-    raw_data_path,
+    preprocessed_data_path,
 )
 from biofefi.services.configuration import load_execution_options, load_plot_options
 from biofefi.services.experiments import get_experiments
@@ -58,7 +58,7 @@ if experiment_name:
 
     data = pd.read_csv(exec_opt.data_path)
 
-    path_to_raw_data = raw_data_path(
+    path_to_raw_data = preprocessed_data_path(
         exec_opt.data_path.split("/")[-1],
         biofefi_base_dir / experiment_name,
     )

--- a/biofefi/services/configuration.py
+++ b/biofefi/services/configuration.py
@@ -8,6 +8,7 @@ from biofefi.options.fi import FeatureImportanceOptions
 from biofefi.options.fuzzy import FuzzyOptions
 from biofefi.options.ml import MachineLearningOptions
 from biofefi.options.plotting import PlottingOptions
+from biofefi.options.preprocessing import PreprocessingOptions
 
 T = TypeVar(
     "T",
@@ -16,6 +17,7 @@ T = TypeVar(
     MachineLearningOptions,
     FeatureImportanceOptions,
     FuzzyOptions,
+    PreprocessingOptions,
 )
 
 
@@ -27,7 +29,7 @@ def load_execution_options(path: Path) -> ExecutionOptions:
         path (Path): The path the `json` file containing the options.
 
     Returns:
-        ExecutionOptions: The plotting options.
+        ExecutionOptions: The execution options.
     """
     with open(path, "r") as json_file:
         options_json = json.load(json_file)
@@ -83,3 +85,19 @@ def load_fi_options(path: Path) -> FeatureImportanceOptions | None:
         fi_options = None
 
     return fi_options
+
+
+def load_data_preprocessing_options(path: Path) -> PreprocessingOptions:
+    """Load data preprocessing options from the given path.
+    The path will be to a `json` file containing the options.
+
+    Args:
+        path (Path): The path the `json` file containing the options.
+
+    Returns:
+        PreprocessingOptions: The data preprocessing options.
+    """
+    with open(path, "r") as json_file:
+        options_json = json.load(json_file)
+    options = PreprocessingOptions(**options_json)
+    return options

--- a/biofefi/services/preprocessing.py
+++ b/biofefi/services/preprocessing.py
@@ -88,7 +88,7 @@ def transform_dependent_variable(transformation_y_method: str, y):
 
 def run_feature_selection(
     preprocessing_opts: PreprocessingOptions, data: pd.DataFrame
-) -> None:
+) -> pd.DataFrame:
     """
     Run feature selection on the data based on the selected methods.
 
@@ -135,7 +135,7 @@ def run_feature_selection(
 
 def run_preprocessing(
     data: pd.DataFrame, experiment_path: Path, config: PreprocessingOptions
-) -> None:
+) -> pd.DataFrame:
 
     X = data.iloc[:, :-1]
     y = data.iloc[:, -1]

--- a/tests/options/test_file_paths.py
+++ b/tests/options/test_file_paths.py
@@ -33,7 +33,7 @@ def test_raw_data_path():
     # Arrange
     experiment_path = fp.biofefi_experiments_base_dir() / "TestExperiment"
     file_name = "test_data.csv"
-    expected_output = experiment_path / "test_data_raw.csv"
+    expected_output = experiment_path / "test_data_preprocessed.csv"
 
     # Act
     actual_output = fp.preprocessed_data_path(file_name, experiment_path)

--- a/tests/options/test_file_paths.py
+++ b/tests/options/test_file_paths.py
@@ -36,7 +36,7 @@ def test_raw_data_path():
     expected_output = experiment_path / "test_data_raw.csv"
 
     # Act
-    actual_output = fp.raw_data_path(file_name, experiment_path)
+    actual_output = fp.preprocessed_data_path(file_name, experiment_path)
 
     # Assert
     assert isinstance(actual_output, Path)

--- a/tests/services/fixtures.py
+++ b/tests/services/fixtures.py
@@ -9,6 +9,7 @@ from biofefi.options.choices.ui import DATA_SPLITS
 from biofefi.options.execution import ExecutionOptions
 from biofefi.options.fi import FeatureImportanceOptions
 from biofefi.options.file_paths import (
+    data_preprocessing_options_path,
     execution_options_path,
     fi_options_dir,
     fi_options_path,
@@ -20,7 +21,6 @@ from biofefi.options.file_paths import (
     log_dir,
     ml_options_path,
     plot_options_path,
-    data_preprocessing_options_path,
 )
 from biofefi.options.fuzzy import FuzzyOptions
 from biofefi.options.ml import MachineLearningOptions

--- a/tests/services/fixtures.py
+++ b/tests/services/fixtures.py
@@ -20,10 +20,12 @@ from biofefi.options.file_paths import (
     log_dir,
     ml_options_path,
     plot_options_path,
+    data_preprocessing_options_path,
 )
 from biofefi.options.fuzzy import FuzzyOptions
 from biofefi.options.ml import MachineLearningOptions
 from biofefi.options.plotting import PlottingOptions
+from biofefi.options.preprocessing import PreprocessingOptions
 from biofefi.utils.utils import delete_directory
 
 
@@ -279,3 +281,63 @@ def previous_fi_results(
     fuzzy_logs = log_dir(exp_dir) / "fuzzy"
     fuzzy_logs.mkdir(parents=True)  # make the intermediate directories
     return exp_dir
+
+
+@pytest.fixture
+def data_preprocessing_opts() -> PreprocessingOptions:
+    """Produce a test instance of `PreprocessingOptions`.
+
+    Returns:
+        PreprocessingOptions: The test instance.
+    """
+    # Arrange
+    return PreprocessingOptions(
+        feature_selection_methods={},
+        correlation_threshold=0.0,
+        variance_threshold=0.0,
+        lasso_regularisation_term=0.0,
+    )
+
+
+@pytest.fixture
+def data_preprocessing_opts_file_path() -> Generator[Path, None, None]:
+    """Produce the test `Path` to some data preprocessing options.
+
+    Delete the file if it has been created by a test.
+
+    Yields:
+        Generator[Path, None, None]: The `Path` to the data preprocessing options file.
+    """
+    # Arrange
+    experiment_path = Path.cwd()
+    options_file = data_preprocessing_options_path(experiment_path)
+    yield options_file
+
+    # Cleanup
+    if options_file.exists():
+        options_file.unlink()
+
+
+@pytest.fixture
+def data_preprocessing_opts_file(
+    data_preprocessing_opts: PreprocessingOptions,
+    data_preprocessing_opts_file_path: Path,
+) -> Path:
+    """Saves an `PreprocessingOptions` object to a file given by `data_preprocessing_opts_file_path`
+    and returns the `Path` to that file.
+
+    Cleanup is handled by the `data_preprocessing_opts_file_path` fixture passed in the second
+    argument.
+
+    Args:
+        data_preprocessing_opts (PreprocessingOptions): PreprocessingOptions options fixture.
+        data_preprocessing_opts_file_path (Generator[Path, None, None]): File path fixture.
+
+    Returns:
+        Path: `data_preprocessing_opts_file_path`
+    """
+    # Arrange
+    options_json = dataclasses.asdict(data_preprocessing_opts)
+    with open(data_preprocessing_opts_file_path, "w") as json_file:
+        json.dump(options_json, json_file, indent=4)
+    return data_preprocessing_opts_file_path

--- a/tests/services/test_configuration.py
+++ b/tests/services/test_configuration.py
@@ -9,6 +9,7 @@ from biofefi.services.configuration import (
     load_execution_options,
     load_fi_options,
     load_plot_options,
+    load_data_preprocessing_options,
     save_options,
 )
 
@@ -90,3 +91,25 @@ def test_load_fi_options(fi_opts: FeatureImportanceOptions, fi_opts_file: Path):
     assert isinstance(opts, FeatureImportanceOptions)
     assert opts == fi_opts
     assert non_existent_opts is None
+
+
+def test_save_data_preprocessing_opts(
+    data_preprocessing_opts: PreprocessingOptions,
+    data_preprocessing_opts_file_path: Path,
+):
+    # Act
+    save_options(data_preprocessing_opts_file_path, data_preprocessing_opts)
+
+    # Assert
+    assert data_preprocessing_opts_file_path.exists()
+
+
+def test_load_data_preprocessing_options(
+    data_preprocessing_opts: PreprocessingOptions, data_preprocessing_opts_file: Path
+):
+    # Act
+    opts = load_data_preprocessing_options(data_preprocessing_opts_file)
+
+    # Assert
+    assert isinstance(opts, PreprocessingOptions)
+    assert opts == data_preprocessing_opts

--- a/tests/services/test_configuration.py
+++ b/tests/services/test_configuration.py
@@ -5,6 +5,7 @@ from biofefi.options.fi import FeatureImportanceOptions
 from biofefi.options.fuzzy import FuzzyOptions
 from biofefi.options.ml import MachineLearningOptions
 from biofefi.options.plotting import PlottingOptions
+from biofefi.options.preprocessing import PreprocessingOptions
 from biofefi.services.configuration import (
     load_data_preprocessing_options,
     load_execution_options,

--- a/tests/services/test_configuration.py
+++ b/tests/services/test_configuration.py
@@ -6,10 +6,10 @@ from biofefi.options.fuzzy import FuzzyOptions
 from biofefi.options.ml import MachineLearningOptions
 from biofefi.options.plotting import PlottingOptions
 from biofefi.services.configuration import (
+    load_data_preprocessing_options,
     load_execution_options,
     load_fi_options,
     load_plot_options,
-    load_data_preprocessing_options,
     save_options,
 )
 


### PR DESCRIPTION
## Description
<!-- Write a description of the changes here -->
- Pre-processed data are now saved in a new file while the raw data is kept in the same file the user uploads
- The form for pre-processing won't show unless the user wants to either re-run pre-processing, or pre-processing hasn't occurred at all
- Create components for pre-processing page
- Create component for the pre-processing form
- Add `data_is_preprocessed` argument to `PreprocessingOptions` with a default of `False`

## Linked issues
<!-- Write a list of issues this PR is related to -->
<!-- e.g.
- #1
- #2
- Closes #3
 -->
- Closes #276 

## (Optional) Screenshots
<!-- Please attach screenshots of UI changes or any other visual change -->
